### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ COALITION creates public ArmA content up to 150 players at https://www.coalition
 
 The Coalition Mission Framework (CMF) is a mission-maker facing framework built inline with the CMF Addon and POTATO Tool. You most likely won't use this unless you were directed here from our community.
 
+You can find information on making missions using the CMF on the [Coalition Group wiki page](https://coalitiongroup.net/wiki/index.php/Mission_Making)
+
 # The Community
 [![COALITION DISCORD](https://img.shields.io/badge/COALITION_Discord-blue)](https://discord.gg/armacoalition)
 


### PR DESCRIPTION
-Add wiki link to README.md
If new mission makers are sent to the github page to grab the CMF file the readme should be a good spot to point them towards the wiki and further information